### PR TITLE
missing import of 'nodes.jinja2"

### DIFF
--- a/hamlish_jinja.py
+++ b/hamlish_jinja.py
@@ -7,7 +7,7 @@
 import re
 import os.path
 
-from jinja2 import  Environment, TemplateSyntaxError, nodes
+from jinja2 import TemplateSyntaxError, nodes
 from jinja2.ext import Extension
 
 __version__ = '0.3.1-dev'


### PR DESCRIPTION
Ohai,

Line 96 you use "nodes" but you don't import it. This patch fix this (and remove an useless import).

Have a nice day and thanks for your awesome lib!
