### PR TITLE
Support parentheses surrounding HTML-style attributes, per Haml reference

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -201,6 +201,20 @@ any order.
     </div>
 
 
+Shortcuts can be used with extended attributes.
+
+.. code-block:: haml
+
+    %div.myclass myattr="myval"
+        Tag Content
+
+.. code-block:: html
+
+    <div class="myclass" myattr="myval">
+        Tag content
+    </div>
+
+
 If these shortcuts are used at the beginning of a line and
 *env.hamlish_enable_div_shortcut* is enabled a div is automatically created.
 
@@ -504,5 +518,3 @@ Example
         {% endhaml %}
         </body>
     </html>
-
-

--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,21 @@ Shortcuts can be used with extended attributes.
     </div>
 
 
+Extended attributes can be enclosed in parentheses as described in the Haml
+reference.
+
+.. code-block:: haml
+
+    %div.myclass(myattr="myval")
+        Tag Content
+
+.. code-block:: html
+
+    <div class="myclass" myattr="myval">
+        Tag content
+    </div>
+
+
 If these shortcuts are used at the beginning of a line and
 *env.hamlish_enable_div_shortcut* is enabled a div is automatically created.
 

--- a/hamlish_jinja.py
+++ b/hamlish_jinja.py
@@ -413,6 +413,8 @@ class Hamlish(object):
 
             attrs = self._parse_shortcut_attributes(attrs)
 
+        elif attrs and attrs[0] == '(' and attrs[-1] == ')':
+            attrs = ' ' + attrs[1:-1]
 
         if self_closing:
             return SelfClosingHTMLTag(tag, attrs)
@@ -423,7 +425,12 @@ class Hamlish(object):
         orig_attrs = attrs
         value = attrs
         extra_attrs = ''
-        if ' ' in value:
+
+        # Extract extra attrs from parentheses, otherwise, split on first space
+        m = re.match(r'^([\.#0-9A-Za-z\-]+)\((.+?)\)$', value)
+        if m:
+            value, extra_attrs = m.group(1), m.group(2)
+        elif ' ' in value:
             value, extra_attrs = attrs.split(' ', 1)
 
         parts = re.split(r'([\.#])', value)

--- a/tests/test_div_shortcut.py
+++ b/tests/test_div_shortcut.py
@@ -171,6 +171,47 @@ class TestSyntax(testing_base.TestCase):
         self.assertEqual(s, r)
 
 
+    def test_shortcut_parenthetic_normal(self):
+        s = self._h('.test(foo="bar")\n  Test')
+        r = '<div class="test" foo="bar">\n  Test\n</div>'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_inline(self):
+        s = self._h('.test(foo="bar") << Test')
+        r = '<div class="test" foo="bar">Test</div>'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_normal2(self):
+        s = self._h('.test.test-1(foo="bar")\n  Test')
+        r = '<div class="test test-1" foo="bar">\n  Test\n</div>'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_inline2(self):
+        s = self._h('.test.test-1(foo="bar") << Test')
+        r = '<div class="test test-1" foo="bar">Test</div>'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_inline3(self):
+        s = self._h('#foo.test.test-1(foo="bar") << Test')
+        r = '<div id="foo" class="test test-1" foo="bar">Test</div>'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_self_closing(self):
+        s = self._h('.test(foo="bar").')
+        r = '<div class="test" foo="bar" />'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_self_closing2(self):
+        s = self._h('.test.test-1(foo="bar").')
+        r = '<div class="test test-1" foo="bar" />'
+        self.assertEqual(s, r)
+
+    def test_shortcut_parenthetic_self_closing3(self):
+        s = self._h('#foo.test.test-1(foo="bar").')
+        r = '<div id="foo" class="test test-1" foo="bar" />'
+        self.assertEqual(s, r)
+
+
     def test_nested_with_shortcuts(self):
         s = self._h('''
 %p -> %span.test
@@ -201,4 +242,3 @@ class TestSyntax(testing_base.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/tests/test_syntax.py
+++ b/tests/test_syntax.py
@@ -323,6 +323,50 @@ def test(name):
         self.assertEqual(s, r)
 
 
+    def test_parenthetic_normal(self):
+        s = self._h('%span(foo="bar")\n  Test')
+        r = '<span foo="bar">\n  Test\n</span>'
+        self.assertEqual(s, r)
+
+    def test_parenthetic_inline(self):
+        s = self._h('%span(foo="bar") << Test')
+        r = '<span foo="bar">Test</span>'
+        self.assertEqual(s, r)
+
+    def test_mixed_parenthetic_normal(self):
+        s = self._h('%span.test-1(foo="bar")\n  Test')
+        r = '<span class="test-1" foo="bar">\n  Test\n</span>'
+        self.assertEqual(s, r)
+
+    def test_mixed_parenthetic_inline(self):
+        s = self._h('%span.test-1(foo="bar") << Test')
+        r = '<span class="test-1" foo="bar">Test</span>'
+        self.assertEqual(s, r)
+
+    def test_mixed_parenthetic_normal2(self):
+        s = self._h('%span#foo.test-1(foo="bar")\n  Test')
+        r = '<span id="foo" class="test-1" foo="bar">\n  Test\n</span>'
+        self.assertEqual(s, r)
+
+    def test_mixed_parenthetic_inline2(self):
+        s = self._h('%span#foo.test-1(foo="bar") << Test')
+        r = '<span id="foo" class="test-1" foo="bar">Test</span>'
+        self.assertEqual(s, r)
+
+    def test_parenthetic_self_closing(self):
+        s = self._h('%span(foo="bar").')
+        r = '<span foo="bar" />'
+        self.assertEqual(s, r)
+
+    def test_mixed_parenthetic_self_closing(self):
+        s = self._h('%span.test-1(foo="bar").')
+        r = '<span class="test-1" foo="bar" />'
+        self.assertEqual(s, r)
+
+    def test_mixed_parenthetic_self_closing2(self):
+        s = self._h('%span#foo.test-1(foo="bar").')
+        r = '<span id="foo" class="test-1" foo="bar" />'
+        self.assertEqual(s, r)
 
 
     def test_line_comment(self):
@@ -524,6 +568,7 @@ def test(name):
                           lambda: self._h('''
 %span -> test1 << test2
 '''))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This would bring hamlish-jinja a bit closer to the Haml reference with the additional support of enclosing parentheses for HTML-style attributes.

My motivation for this pull request is due to my use of the Jetbrains Haml plugin for IDEA/PyCharm. A recent update to this plugin resulted in valid code from this dialect of Haml to complain with the warning: "Illegal nesting: content can't be both given on the same line as [tag] and nested within it."

I did not bump the version nor add to the REAME "added in version x.x.x" since I wasn't sure if this would go in 0.3.x or 0.4.0.
